### PR TITLE
Remove pid line which conflicts with heroku deployment

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,7 +16,7 @@ port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RACK_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together


### PR DESCRIPTION
Fix line in puma.rb which causes app to crash on Heroku.  Now we are officially on Ruby 2.7.4 and Rails 5.2.0

Resolves issue #175