### PR TITLE
fix Deprecation of string as raw SQL argument

### DIFF
--- a/app/controllers/biodiversity_reports_controller.rb
+++ b/app/controllers/biodiversity_reports_controller.rb
@@ -50,7 +50,7 @@ class BiodiversityReportsController < ApplicationController
 
   def load_plots_and_plants
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def set_biodiversity_report

--- a/app/controllers/mycorrhizal_fungi_samples_controller.rb
+++ b/app/controllers/mycorrhizal_fungi_samples_controller.rb
@@ -12,12 +12,12 @@ class MycorrhizalFungiSamplesController < ApplicationController
   def new
     @mycorrhizal_fungi_sample = MycorrhizalFungiSample.new
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def edit
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def create
@@ -29,7 +29,7 @@ class MycorrhizalFungiSamplesController < ApplicationController
         format.json { render :show, status: :created, location: @mycorrhizal_fungi_sample }
       else
         @plots = Plot.order(:plot_id)
-        @plants = Plant.order('LOWER(common_name)')
+        @plants = Plant.order(Arel.sql('LOWER(common_name)'))
         format.html { render :new }
         format.json { render json: @mycorrhizal_fungi_sample.errors, status: :unprocessable_entity }
       end
@@ -43,7 +43,7 @@ class MycorrhizalFungiSamplesController < ApplicationController
         format.json { render :show, status: :ok, location: @mycorrhizal_fungi_sample }
       else
         @plots = Plot.order(:plot_id)
-        @plants = Plant.order('LOWER(common_name)')
+        @plants = Plant.order(Arel.sql('LOWER(common_name)'))
         format.html { render :edit }
         format.json { render json: @mycorrhizal_fungi_sample.errors, status: :unprocessable_entity }
       end

--- a/app/controllers/plant_samples_controller.rb
+++ b/app/controllers/plant_samples_controller.rb
@@ -23,12 +23,12 @@ class PlantSamplesController < ApplicationController
   def new
     @plant_sample = PlantSample.new
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def edit
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def create
@@ -39,7 +39,7 @@ class PlantSamplesController < ApplicationController
       flash[:success] = 'Plant sample was successfully created.'
     else
       @plots = Plot.order(:plot_id)
-      @plants = Plant.order('LOWER(common_name)')
+      @plants = Plant.order(Arel.sql('LOWER(common_name)'))
       render :new
     end
   end
@@ -50,7 +50,7 @@ class PlantSamplesController < ApplicationController
       flash[:success] = 'Plant sample was successfully updated.'
     else
       @plots = Plot.order(:plot_id)
-      @plants = Plant.order('LOWER(common_name)')
+      @plants = Plant.order(Arel.sql('LOWER(common_name)'))
       render :edit
     end
   end

--- a/app/controllers/plots_controller.rb
+++ b/app/controllers/plots_controller.rb
@@ -11,7 +11,7 @@ class PlotsController < ApplicationController
 
   def new
     @plot = Plot.new
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def edit

--- a/app/controllers/species_variation_observations_controller.rb
+++ b/app/controllers/species_variation_observations_controller.rb
@@ -13,12 +13,12 @@ class SpeciesVariationObservationsController < ApplicationController
   def new
     @species_variation_observation = SpeciesVariationObservation.new
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def edit
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def create
@@ -30,7 +30,7 @@ class SpeciesVariationObservationsController < ApplicationController
         format.json { render :show, status: :created, location: @species_variation_observation }
       else
         @plots = Plot.order(:plot_id)
-        @plants = Plant.order('LOWER(common_name)')
+        @plants = Plant.order(Arel.sql('LOWER(common_name)'))
         format.html { render :new }
         format.json { render json: @species_variation_observation.errors, status: :unprocessable_entity }
       end
@@ -44,7 +44,7 @@ class SpeciesVariationObservationsController < ApplicationController
         format.json { render :show, status: :ok, location: @species_variation_observation }
       else
         @plots = Plot.order(:plot_id)
-        @plants = Plant.order('LOWER(common_name)')
+        @plants = Plant.order(Arel.sql('LOWER(common_name)'))
         format.html { render :edit }
         format.json { render json: @species_variation_observation.errors, status: :unprocessable_entity }
       end

--- a/app/controllers/tree_samples_controller.rb
+++ b/app/controllers/tree_samples_controller.rb
@@ -16,12 +16,12 @@ class TreeSamplesController < ApplicationController
   def new
     @tree_sample = TreeSample.new
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def edit
     @plots = Plot.order(:plot_id)
-    @plants = Plant.order('LOWER(common_name)')
+    @plants = Plant.order(Arel.sql('LOWER(common_name)'))
   end
 
   def create
@@ -33,7 +33,7 @@ class TreeSamplesController < ApplicationController
         format.json { render :show, status: :created, location: @tree_sample }
       else
         @plots = Plot.order(:plot_id)
-        @plants = Plant.order('LOWER(common_name)')
+        @plants = Plant.order(Arel.sql('LOWER(common_name)'))
         format.html { render :new }
         format.json { render json: @tree_sample.errors, status: :unprocessable_entity }
       end
@@ -47,7 +47,7 @@ class TreeSamplesController < ApplicationController
         format.json { render :show, status: :ok, location: @tree_sample }
       else
         @plots = Plot.order(:plot_id)
-        @plants = Plant.order('LOWER(common_name)')
+        @plants = Plant.order(Arel.sql('LOWER(common_name)'))
         format.html { render :edit }
         format.json { render json: @tree_sample.errors, status: :unprocessable_entity }
       end


### PR DESCRIPTION
Fix #200 
Changed 'LOWER(common_name)' to Arel.sql('LOWER(common_name)') to fix deprecation warning.