### PR TITLE
fix javascript issues with rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # RVM
 .ruby-version
 .ruby-gemset
+.rvmrc
 
 # Ignore bundler config.
 /.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
@@ -216,6 +217,9 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.8)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -397,6 +401,7 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/views/biodiversity_reports/edit.html.haml
+++ b/app/views/biodiversity_reports/edit.html.haml
@@ -1,3 +1,2 @@
-- provide(:javascript, javascript_pack_tag('biodiversity_reports'))
 - content_for_title('Edit Biodiversity Report')
 = render partial: 'form'

--- a/app/views/biodiversity_reports/new.html.haml
+++ b/app/views/biodiversity_reports/new.html.haml
@@ -1,3 +1,2 @@
-- provide(:javascript, javascript_pack_tag('biodiversity_reports'))
 - content_for_title('New Biodiversity Report')
 = render partial: 'form'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,13 +29,13 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :helper
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Paperclip::Shoulda::Matchers
-  # https://github.com/rails/webpacker/issues/59
-  config.before :suite do
-    `bin/webpack`
-    Timeout.timeout(300) do
-      loop until Webpacker.config.public_manifest_path.exist?
-    end
-  end
+  # # https://github.com/rails/webpacker/issues/59
+  # config.before :suite do
+  #   `bin/webpack`
+  #   Timeout.timeout(300) do
+  #     loop until Webpacker.config.public_manifest_path.exist?
+  #   end
+  # end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
remove calls to webpack to fix rspec warnings and to stop webpack breaking the new/edit biodiversity report pages