### PR TITLE
Changed the biomass estimate and temperature labels to include units

### DIFF
--- a/app/views/biodiversity_reports/_form.html.haml
+++ b/app/views/biodiversity_reports/_form.html.haml
@@ -25,7 +25,7 @@
           = form.label :diversity_index, 'Shannon-Wiener Diversity Index'
           = form.text_field :diversity_index, class: 'form-control'
         .data
-          = form.label :biomass_estimate, 'Biomass Estimate'
+          = form.label :biomass_estimate, 'Biomass Estimate (grams per square meter)'
           = form.text_field :biomass_estimate, class: 'form-control'
     = render 'layouts/image_gallery', {form: form, entity: @biodiversity_report, phrase: 'Include reference pictures for the report'}
     = render 'layouts/form_buttons', form: form

--- a/app/views/biodiversity_reports/index.html.haml
+++ b/app/views/biodiversity_reports/index.html.haml
@@ -11,11 +11,11 @@
         %th{scope: 'col'} ID
         %th{scope: 'col'} Measured On
         %th{scope: 'col'} Plot
-        %th{scope: 'col'} Temperature
+        %th{scope: 'col'} Temperature (celsius)
         %th{scope: 'col'} Species Richness
         %th{scope: 'col'} Diversity Index
         %th{scope: 'col'} Species Evenness
-        %th{scope: 'col'} Biomass Estimate
+        %th{scope: 'col'} Biomass Estimate (grams per square meter)
     %tbody
       - @biodiversity_reports.each do |report|
         %tr{:onclick => "location.href='#{url_for(report)}'"}

--- a/app/views/biodiversity_reports/show.html.haml
+++ b/app/views/biodiversity_reports/show.html.haml
@@ -25,7 +25,7 @@
           %th{scope: 'row'} Plot
           %td= link_to(@biodiversity_report.plot)
         %tr
-          %th{scope: 'row'} Temperature
+          %th{scope: 'row'} Temperature (celsius)
           %td= @biodiversity_report.temperature
         %tr
           %th{scope: 'row'} Species Richness
@@ -37,7 +37,7 @@
           %th{scope: 'row'} Species Evenness
           %td= @biodiversity_report.species_evenness
         %tr
-          %th{scope: 'row'} Biomass Estimate
+          %th{scope: 'row'} Biomass Estimate (grams per square meter)
           %td= @biodiversity_report.biomass_estimate
 
 - if @biodiversity_reports

--- a/app/views/plant_samples/_form.html.haml
+++ b/app/views/plant_samples/_form.html.haml
@@ -22,7 +22,7 @@
           = form.label :percent_cover, 'Coverage'
           = form.text_field :percent_cover, class: 'form-control'
         .data
-          = form.label :biomass_estimate, 'Biomass Estimate'
+          = form.label :biomass_estimate, 'Biomass Estimate (grams per square meter)'
           = form.text_field :biomass_estimate, class: 'form-control'
     = render 'layouts/image_gallery', {form: form, entity: @plant_sample, phrase: 'Include reference pictures for the sample'}
     = render 'layouts/form_buttons', {form: form, text: 'Sample'}

--- a/app/views/plant_samples/show.html.haml
+++ b/app/views/plant_samples/show.html.haml
@@ -31,5 +31,5 @@
           %th{scope: 'row'} Percent Cover
           %td= @plant_sample.percent_cover
         %tr
-          %th{scope: 'row'} Biomass Estimate
+          %th{scope: 'row'} Biomass Estimate (grams per square meter)
           %td= @plant_sample.biomass_estimate

--- a/app/views/plots/show.html.haml
+++ b/app/views/plots/show.html.haml
@@ -104,7 +104,7 @@
         %thead
           %tr
             %th{scope: 'col'} Measured On
-            %th{scope: 'col'} Temperature
+            %th{scope: 'col'} Temperature (grams per square meter)
             %th{scope: 'col'} Species Richness
             %th{scope: 'col'} Diversity Index
         %tbody

--- a/spec/features/user_creates_biodiversity_report_spec.rb
+++ b/spec/features/user_creates_biodiversity_report_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'User creates a biodiversity report' do
     fill_in('Species Richness', with: '10')
     fill_in('Shannon-Wiener Diversity Index', with: '5.0')
     fill_in('Species Evenness', with: '0.5')
-    fill_in('Biomass Estimate', with: '1.0')
+    fill_in('Biomass Estimate (grams per square meter)', with: '1.0')
     click_button('Create Report')
     expect(page).to have_selector '.alert', text: 'Biodiversity report was successfully created.'
   end

--- a/spec/features/user_creates_plant_sample_spec.rb
+++ b/spec/features/user_creates_plant_sample_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'User creates a plant sample' do
     select('Plant Example', from: 'Plant')
     fill_in('Abundance', with: 1)
     fill_in('Coverage', with: 1)
-    fill_in('Biomass Estimate', with: 1.0)
+    fill_in('Biomass Estimate (grams per square meter)', with: 1.0)
     click_on('Create Sample')
     expect(page).to have_content('Plant sample was successfully created')
   end


### PR DESCRIPTION
The units included were "grams per square meter" for biomass and "celsius" for temperature. It may be confusing for users who are entering information without having a consistent unit of measurement for this data.